### PR TITLE
Remove request for help for page-as-oneline problem.

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,12 +225,6 @@ some information, feel free to <a
     href="https://github.com/vimberlin/vimberlin.de">fork it</a> and send in a pull request.
 
 
-Unfortunately this site is mangled when accessed via a mobile carrier. They are
-stripping white space - including new lines within the tags. This results in
-vimberlin.de being a one liner. If you know a way to stop them from doing so (as
-a website provider), please let me know.
-
-
 Vim is charityware. If you're enjoying the vimberlin user group or you want to
 support Vim development, please consider <a href="http://iccf-holland.org/"
     >helping needy children in Uganda</a> and


### PR DESCRIPTION
Following the discussion at https://github.com/vimberlin/vimberlin.de/commit/da17e02c1aeb41c2851a1f89ac61a4c3712a0256#index.html the commit c1474c6b appears to have fixed this.
