### PR TITLE
correct names of speakers by swapping them

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,10 +71,10 @@ Recap: Second Meetup - 2012-03-22
 First of all: Thank you all for coming, thanks to the two Matthiases for
 preparing and giving a talk and thanks to LAUNCH/CO for having us.
 
-The slides of Matthias Viehweger's talk "Lessons learned with Vimscript" may be
+The slides of Matthias Guenther's talk "Lessons learned with Vimscript" may be
 found <a
 href="http://speakerdeck.com/u/wikimatze/p/lessons-learned-with-vimscript"
->at Speakerdeck</a>. Matthias Guenther's talk was more ad-hoc a.k.a. lightning
+>at Speakerdeck</a>. Matthias Viehweger's talk was more ad-hoc a.k.a. lightning
 talk style, and he did not use slides. So if you are interested in his
 introduction to <a
 href="https://github.com/tpope/vim-rails">rails.vim</a> and the <a
@@ -83,7 +83,7 @@ href="http://www.vim.org/scripts/script.php?script_id=356"
 person.
 
 We've again had lots of interesting discussions about folding, navigation and
-other Vim best practices. In this context Matthias Viehweger mentioned his
+other Vim best practices. In this context Matthias Guenther mentioned his
 <a href="https://github.com/matthias-guenther/tocdown"
 >tocdown plugin</a>, Drew Neil mentioned his <a
 href="https://github.com/nelstrom/dotfiles/blob/master/vim/ftplugin/markdown/folding.vim"


### PR DESCRIPTION
It was bound to happen. Two speakers of almost identical name. They just had to be mixed up.

But credit where credit is due, @matthias-guenther did an awesome first talk. Therefore I swapped our names :)
