### PR TITLE
Fix november meetup date an link to github repo.

### DIFF
--- a/_posts/2012-11-22-november-2012-meetup.md
+++ b/_posts/2012-11-22-november-2012-meetup.md
@@ -17,7 +17,7 @@ We currently have the three talks on the agenda:
     <li>
       <strong>"Creating a color scheme for Vim"</strong>
       <br />
-      Niels Madan will talk about his experiences in creating <a href="git://github.com/nielsmadan/harlequin.git">harlequin</a>
+      Niels Madan will talk about his experiences in creating <a href="https://github.com/nielsmadan/harlequin">harlequin</a>
     </li>
     <li>
       <strong>"Small Commands"</strong>


### PR DESCRIPTION
I was looking at the home page and saw that the date for the november meetup was set to the 7th (and thought I had totally missed it).

So I changed it to the 22nd and also changed the link to the harlequin repo, which was broken.
