### PR TITLE
Renamed config parameter and fixed ical plugin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ permalink: /:title
 rdiscount:
   extensions: [smart]
 
-siteurl: http://vimberlin.de
+url: http://vimberlin.de
 
 locations:
   buero20:

--- a/_plugins/ical_generator.rb
+++ b/_plugins/ical_generator.rb
@@ -42,7 +42,7 @@ module Jekyll
               event.dtstart     = Time.parse post.data['when']
               event.dtend       = Time.parse post.data['ends']
               event.location    = location
-              event.url         = site.config['siteurl'] + post.url
+              event.url         = site.config['url'] + post.url
             end
           end
         end


### PR DESCRIPTION
The `url` config parameter was not set. Instead I used a custom
`siteurl` value. Due this the `site.url` call in `atom.xml` was empty.
So the url was relativ to the domain which leads to:

http://feeds.feedburner.com/january-2014-meetup

I renamed the siteurl parameter which hopefully should match the jerkyll
doku: http://jekyllrb.com/docs/configuration/

Oh I miss static typing ...
