### PR TITLE
fix(config): enable raw HTML in markdown renderer

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -74,3 +74,7 @@ summarylength = 30
 
 [permalinks]
   posts = "/:title/"
+
+## Markup
+[markup.goldmark.renderer]
+ unsafe = true


### PR DESCRIPTION
Older Hugo (pre-0.60) used Blackfriday which allowed raw HTML by default. Hugo 0.60+ switched to Goldmark with unsafe = false as default for security.

This config.toml was created in 2012 and never updated for this Hugo change 😄 